### PR TITLE
Adding cash endpoint

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -32,6 +32,14 @@ class GetUserSchema(BaseModel):
     class Config:
         from_attributes = True
 
+class AddCashRegisterSchema(BaseModel):
+    access_token: str
+    add_codigo_usuario: str
+    adicionar_caixa: str
+
+    class Config:
+        from_attributes = True
+
 class CategorySchema(BaseModel):
     access_token: str
     codigo_categoria: int


### PR DESCRIPTION
Added a new endpoint:

- /CashRegister: This endpoint is used to add money to a user Cash Registry


Modified the /confirm endpoint for notes:

- When a user saves a new note, its value is deducted from their "cash register."